### PR TITLE
Secure Raspberry Pi with PubNub PAM token

### DIFF
--- a/pi/pubnub_client.py
+++ b/pi/pubnub_client.py
@@ -11,6 +11,7 @@ load_dotenv()
 
 PUBLISH_KEY = os.getenv("PUBNUB_PUBLISH_KEY")
 SUBSCRIBE_KEY = os.getenv("PUBNUB_SUBSCRIBE_KEY")
+PI_TOKEN = os.getenv("PUBNUB_PI_TOKEN")
 
 if not PUBLISH_KEY or not SUBSCRIBE_KEY:
     raise ValueError("PubNub keys are not set in environment variables.")
@@ -18,7 +19,8 @@ if not PUBLISH_KEY or not SUBSCRIBE_KEY:
 pnconfig = PNConfiguration()
 pnconfig.publish_key = PUBLISH_KEY
 pnconfig.subscribe_key = SUBSCRIBE_KEY
-pnconfig.uuid = "home-automation-system"
+pnconfig.uuid = "raspberry-pi-01"
+pnconfig.auth_key = PI_TOKEN
 
 pubnub = PubNub(pnconfig)
 

--- a/server/pubnub_access.py
+++ b/server/pubnub_access.py
@@ -1,7 +1,10 @@
 import os
+from dotenv import load_dotenv
 from pubnub.pubnub import PubNub
 from pubnub.pnconfiguration import PNConfiguration
 from pubnub.models.consumer.v3.channel import Channel
+
+load_dotenv()
 
 
 def get_pubnub_admin():
@@ -26,6 +29,25 @@ def generate_user_token(user_id, role="user"):
         .channels(channels)
         .authorized_uuid(str(user_id))
         .ttl(60)
+        .sync()
+    )
+
+    return envelope.result.token
+
+
+def generate_pi_token():
+    pubnub = get_pubnub_admin()
+
+    envelope = (
+        pubnub.grant_token()
+        .authorized_uuid("raspberry-pi-01")
+        .ttl(1440)  # 24 hours
+        .channels(
+            [
+                Channel.id("home-automation-sensor-data").write(),
+                Channel.id("home-automation-control").read(),
+            ]
+        )
         .sync()
     )
 


### PR DESCRIPTION
- Added PubNub PAM token for Raspberry Pi authentication
- The Pi client now authenticates using an auth_key generated by the server with PubNub Access Manager.
- Access is restricted to publishing sensor data and subscribing to control messages only.
- This removes public PubNub access and enforces least privilege communication for the IoT device.